### PR TITLE
hotfix/94-meeting-validator

### DIFF
--- a/nexong/api/Meeting/meetingSerializer.py
+++ b/nexong/api/Meeting/meetingSerializer.py
@@ -13,18 +13,3 @@ class MeetingSerializer(ModelSerializer):
     class Meta:
         model = Meeting
         fields = ["id", "name", "description", "date", "time", "attendees", "url"]
-
-    def validate(self, data):
-        student = data["student"]
-        lesson_event = data["lesson_event"]
-        if CenterExitAuthorization.objects.filter(
-            student=student, lesson_event=lesson_event
-        ).exists():
-            raise serializers.ValidationError(
-                "An authorization for this student and lesson event already exists."
-            )
-        if not LessonEvent.objects.get(lesson_event).students.contains(student):
-            raise serializers.ValidationError(
-                "This student is not enrolled in this lesson, therefore cannot assist to this lesson event."
-            )
-        return data


### PR DESCRIPTION
The validator of the centreexit_auth was copypasted in the meeting serializer. I was responsible for this and i do not remember doing so, either way im sorry for this error. Now it has been removed, allowing the meeting API to work correctly.

To check that it has been corrected, enter the meeting API section and verify that you can send or recieve info.