### PR TITLE
hotfix/169 fix download privileges

### DIFF
--- a/nexong/api/middleware.py
+++ b/nexong/api/middleware.py
@@ -1,0 +1,14 @@
+from django.http import HttpResponseForbidden
+
+class ExportPermission:
+    def __init__(self, response):
+        self.response = response
+
+    def __call__(self, request):
+        
+        if "export" in request.path:
+            if not request.user.is_authenticated or not request.user.role == "ADMIN":
+                return HttpResponseForbidden("Acceso denegado") 
+
+        return self.response(request)
+      

--- a/nexong/api/middleware.py
+++ b/nexong/api/middleware.py
@@ -1,14 +1,13 @@
 from django.http import HttpResponseForbidden
 
+
 class ExportPermission:
     def __init__(self, response):
         self.response = response
 
     def __call__(self, request):
-        
         if "export" in request.path:
             if not request.user.is_authenticated or not request.user.role == "ADMIN":
-                return HttpResponseForbidden("Acceso denegado") 
+                return HttpResponseForbidden("Acceso denegado")
 
         return self.response(request)
-      

--- a/nexong/api/middleware.py
+++ b/nexong/api/middleware.py
@@ -1,13 +1,24 @@
 from django.http import HttpResponseForbidden
-
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
 class ExportPermission:
-    def __init__(self, response):
-        self.response = response
+    
+    def __init__(self, get_response):
+        self.get_response = get_response
 
     def __call__(self, request):
+        
         if "export" in request.path:
-            if not request.user.is_authenticated or not request.user.role == "ADMIN":
+            authorization_header = request.headers.get("Authorization")
+            if not authorization_header:
                 return HttpResponseForbidden("Acceso denegado")
 
-        return self.response(request)
+            jwt_authentication = JWTAuthentication()
+
+            user, _ = jwt_authentication.authenticate(request)
+            if user.role != "ADMIN":
+                    return HttpResponseForbidden("Acceso denegado")           
+            
+
+        return self.get_response(request)
+      

--- a/src/settings.py
+++ b/src/settings.py
@@ -53,7 +53,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
     "nexong.api.middleware.ExportPermission",
-
 ]
 SESSION_ENGINE = "django.contrib.sessions.backends.db"
 ROOT_URLCONF = "src.urls"

--- a/src/settings.py
+++ b/src/settings.py
@@ -52,6 +52,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
+    "nexong.api.middleware.ExportPermission",
+
 ]
 SESSION_ENGINE = "django.contrib.sessions.backends.db"
 ROOT_URLCONF = "src.urls"


### PR DESCRIPTION
Since the download urls are not views, I added a middleware that checks the path looking if it's an export url and then checks if the user is loged as admin otherwise it rejects the access.

I couldn't use the Response from django rest like in the views so I used a normal HTTP response for it, let me know if you want any change on it.

And last remember in order to try some export urls you need to have true pdf files in the database.

